### PR TITLE
copyedit, adding "lang" html attributes

### DIFF
--- a/devanagari.html
+++ b/devanagari.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 	<head>
 		<title>Learn Devanagari (देवनागरी)</title>
 		<meta charset="utf-8">
-		<meta name="description" content="Online flashcard quiz to learn and practice Devanagari">
+		<meta name="description" content="Flashcards for learning and practicing Devanagari">
 		<meta name="viewport" content="width=device-width, initial-scale=1">
 		<script>
 			const charsets = [
@@ -1319,7 +1319,7 @@
 					"ळ्क्ष", "ḷkṣa",
 					"ळ्ज्ञ", "ḷjña",], checked: false,},
 
-				"<hr />velars (kaṇṭhya)",
+				"<hr>velars (<span lang="hi-Latn">kaṇṭhya</span>)",
 
 				{name:"k-row",
 					chars:[
@@ -1447,7 +1447,7 @@
 						"हः", "haḥ",
 						"हॉ", "hô",], checked: false,},
 
-				"<hr />palatals (tālavya)",
+				"<hr>palatals (<span lang="hi-Latn">tālavya</span>)",
 
 				{name:"c-row",
 					chars:[
@@ -1596,7 +1596,7 @@
 						"शः", "śaḥ",
 						"शॉ", "śô",], checked: false,},
 
-				"<hr />retroflexes (mūrdhanya)",
+				"<hr>retroflexes (<span lang="hi-Latn">mūrdhanya</span>)",
 
 				{name:"ṭ-row",
 					chars:[
@@ -1745,7 +1745,7 @@
 						"षः", "ṣaḥ",
 						"षॉ", "ṣô",], checked: false,},
 
-				"<hr />dentals (dantya)",
+				"<hr>dentals (<span lang="hi-Latn">dantya</span>)",
 
 				{name:"t-row",
 					chars:[
@@ -1894,7 +1894,7 @@
 						"सः", "saḥ",
 						"सॉ", "sô",], checked: false,},
 
-				"<hr />labials (oṣṭhya)",
+				"<hr>labials (<span lang="hi-Latn">oṣṭhya</span>)",
 
 				{name:"p-row",
 					chars:[
@@ -2022,7 +2022,7 @@
 						"वः", "vaḥ",
 						"वॉ", "vô",], checked: false,},
 
-				"<hr />", 
+				"<hr>", 
 
 				{name:"numerals",
 				chars:[
@@ -2092,9 +2092,9 @@
 	<body style="text-align: center;">
 		<h1>Learn Devanagari</h1>
 		from <a href="index.html">LearnScripts</a>
-		<br /><br />
+		<br><br>
 		<div id="app">
-			<div id="noapp">Not loaded. <br /><br /> You may be using an incompatible browser or have turned Javascript off.</div>
+			<div id="noapp">Not loaded. <br><br> You may be using an incompatible browser or have turned Javascript off.</div>
 		</div>
 		<script type="text/javascript" src="app.js"></script>
 		<script type="text/javascript">
@@ -2109,14 +2109,14 @@
 		<h3>How to Read IAST</h3>
 		<p>The diacritic marks used in IAST are the above-dot&nbsp;(<small>&nbsp;</small><sup>·</sup><small>&nbsp;</small>), the below-dot&nbsp;(<small>&nbsp;</small><sub>.</sub><small>&nbsp;</small>), the caron (<small>&nbsp;</small>^<small>&nbsp;</small>), the tilde&nbsp;(<small>&nbsp;</small><sup>~</sup><small>&nbsp;</small>), the acute&nbsp;(<small>&nbsp;</small>´<small>&nbsp;</small>), and the macron&nbsp;(<small>&nbsp;</small>‾<small>&nbsp;</small>).</p>
 		<ul>
-			<li>A vowel with a macron above should be read as long. For example <strong>"ā"</strong> should be read as <strong>"ah"</strong> /ɑː/.</li>
+			<li>A vowel with a macron above should be read as long. For example <strong lang="hi-Latn">"ā"</strong> should be read as <strong>"ah"</strong> <span lang="und-Latn-fonipa">/ɑː/</span>.</li>
 			<li>When a consonant has an dot beneath it, this means it is <a href="https://en.wikipedia.org/wiki/retroflex">
 			retroflex</a>. It should be pronounced with the tongue bent back agianst the alveolar ridge.</li>
-			<li>The <strong>"ṅ"</strong> with the dot above is <a href="https://en.wikipedia.org/wiki/velar">velar</a>. It should be pronounced /ŋ/ like <strong>"ng"</strong> in English "si<strong>ng</strong>."</li>
-			<li>The <strong>"ñ"</strong> with a tilde above is <a href="https://en.wikipedia.org/wiki/Palatal_consonant">palatal</a>. It should be pronounced /ɲ/, roughly the <strong>"ny"</strong> in English "<strong>ny</strong>an cat."</li>
-			<li>The <strong>"ś"</strong> with an acute above is another palatal. It should be pronounced /ʃ/, like <strong>"sh"</strong> in English "<strong>sh</strong>ine."</li>
-			<li><strong>"ê"</strong> and <strong>"ô"</strong> are pronounced /æ/ and /ɒ/ respectively.</li>
-			<li><strong>"th"</strong> is <strong>not</strong> pronounced as in English "<span style="color: red;">th</span>orn", but as an aspirated <strong>"t"</strong> sound /t̪ʰ/.</li>
+			<li>The <strong lang="hi-Latn">"ṅ"</strong> with the dot above is <a href="https://en.wikipedia.org/wiki/velar">velar</a>. It should be pronounced <span lang="und-Latn-fonipa">/ŋ/</span> like <strong>"ng"</strong> in English "si<strong>ng</strong>."</li>
+			<li>The <strong lang="hi-Latn">"ñ"</strong> with a tilde above is <a href="https://en.wikipedia.org/wiki/Palatal_consonant">palatal</a>. It should be pronounced <span lang="und-Latn-fonipa">/ɲ/</span>, roughly the <strong>"ny"</strong> in English "<strong>ny</strong>an cat."</li>
+			<li>The <strong lang="hi-Latn">"ś"</strong> with an acute above is another palatal. It should be pronounced <span lang="und-Latn-fonipa">/ʃ/</span>, like <strong>"sh"</strong> in English "<strong>sh</strong>ine."</li>
+			<li><strong lang="hi-Latn">"ê"</strong> and <strong lang="hi-Latn">"ô"</strong> are pronounced <span lang="und-Latn-fonipa">/æ/</span> and <span lang="und-Latn-fonipa">/ɒ/</span>, respectively.</li>
+			<li><strong lang="hi-Latn">"th"</strong> is <strong>not</strong> pronounced as in English "<span style="color: red;">th</span>orn", but as an aspirated <strong>"t"</strong> sound <span lang="und-Latn-fonipa">/t̪ʰ/</span>.</li>
 		</ul>
 	</body>
 </html>

--- a/index.html
+++ b/index.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 	<head>
 		<title>Learn Scripts!</title>
 		<meta charset="utf-8">
-		<meta name="description" content="A collection of free reasources and interactive tools for learning to read the writing systems of the world.">
+		<meta name="description" content="A collection of resources and tools for learning non-Latin writing systems.">
 		<meta name="viewport" content="width=device-width, initial-scale=1">
 		<link rel="stylesheet" href="styles.css">
 		<style>
@@ -28,21 +28,21 @@ background-size: 0.5em 0.5em;
 	<section class="a">
 		<h1>Learn Scripts Online!</h1>
 		<p>
-			A collection of free reasources and interactive tools for learning to read the writing systems of the world.
+			A collection of resources and tools for learning non-Latin writing systems.
 		</p>
 	</section>
 	<section class="a">
-		Scripts available to study:
+		Scripts currently available:
 		<ul>
-			<li><a href="hiragana.html">Hiragana</a> (ひらがな)</li>
-			<li><a href="katakana.html">Katakana</a> (カタカナ)</li>
-			<li><a href="hebrew.html">Hebrew Alphabet</a> (<span style="font-family: serif">עִבְרִית</span>)</li>
-			<li><a href="georgian.html">Georgian Alphabet</a> (მხედრული)</li>
-			<li><a href="greek.html">Greek Alphabet</a> (ἀλφάβητος)</li>
-			<li><a href="glagolitic.html">Glagolitic</a> (ⰳⰾⰰⰳⱁⰾⰹⱌⰰ)</li>
-			<li><a href="r-cyrillic.html">Russian Cyrillic</a> (Пусский Кири́ллица)</li>
-			<li><a href="devanagari.html">Devanagari</a> (देवनागरी)</li>
-			<li><a href="zhuyin.html">Bopomofo</a> (ㄅㄆㄇㄈ) a.k.a. Zhuyin</li>
+			<li><a href="hiragana.html">Hiragana</a> (<span lang="ja">ひらがな</span>)</li>
+			<li><a href="katakana.html">Katakana</a> (<span lang="ja">カタカナ</span>)</li>
+			<li><a href="hebrew.html">Hebrew Alphabet</a> (<span lang="he" style="font-family: serif">עִבְרִית</span>)</li>
+			<li><a href="georgian.html">Georgian Alphabet</a> (<span lang="ka">მხედრული</span>)</li>
+			<li><a href="greek.html">Greek Alphabet</a> (<span lang="el">ἀλφάβητος</span>)</li>
+			<li><a href="glagolitic.html">Glagolitic</a> (<span lang="cu-Glag">ⰳⰾⰰⰳⱁⰾⰹⱌⰰ</span>)</li>
+			<li><a href="r-cyrillic.html">Russian Cyrillic</a> (<span lang="ru">Пусский Кири́ллица</span>)</li>
+			<li><a href="devanagari.html">Devanagari</a> (<span lang="hi">देवनागरी</span>)</li>
+			<li><a href="zhuyin.html">Bopomofo/Zhuyin</a> (<span lang="zh-Bopo">ㄅㄆㄇㄈ</span>) </li>
 		</ul>
 	</section>
 </body>

--- a/index.html
+++ b/index.html
@@ -42,7 +42,7 @@ background-size: 0.5em 0.5em;
 			<li><a href="glagolitic.html">Glagolitic</a> (<span lang="cu-Glag">ⰳⰾⰰⰳⱁⰾⰹⱌⰰ</span>)</li>
 			<li><a href="r-cyrillic.html">Russian Cyrillic</a> (<span lang="ru">Пусский Кири́ллица</span>)</li>
 			<li><a href="devanagari.html">Devanagari</a> (<span lang="hi">देवनागरी</span>)</li>
-			<li><a href="zhuyin.html">Bopomofo/Zhuyin</a> (<span lang="zh-Bopo">ㄅㄆㄇㄈ</span>) </li>
+			<li><a href="zhuyin.html">Bopomofo/Zhuyin</a> (<span lang="zh-Bopo">ㄅㄆㄇㄈ</span>)</li>
 		</ul>
 	</section>
 </body>


### PR DESCRIPTION
lang attributes are important for semantic and accessibility reasons, see https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/lang